### PR TITLE
Corregir fecha adelantada un día

### DIFF
--- a/src/features/arbitrage/ArbitrajeApp.jsx
+++ b/src/features/arbitrage/ArbitrajeApp.jsx
@@ -17,6 +17,7 @@ import {
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Legend, ResponsiveContainer } from 'recharts';
 import { formatAmountWithCurrency } from '../../shared/components/forms';
 import { safeParseFloat } from '../../shared/services/safeOperations';
+import { getTodayLocalDate, getCurrentYearMonth, isCurrentMonth, isToday } from '../../shared/utils/dateUtils';
 
 /** COMPONENTE PRINCIPAL DE ANÁLISIS DE ARBITRAJE */
 function ArbitrajeApp({ movements, onNavigate }) {
@@ -75,11 +76,11 @@ function ArbitrajeApp({ movements, onNavigate }) {
 
   // Calcular ganancias del mes actual
   const currentMonthArbitrageProfits = useMemo(() => {
-    const currentYearMonth = new Date().toISOString().substring(0, 7);
+    const currentYearMonth = getCurrentYearMonth();
     const monthly = {};
 
     arbitrageMovements.forEach(mov => {
-      if (mov.fecha && mov.fecha.substring(0, 7) === currentYearMonth) {
+      if (mov.fecha && isCurrentMonth(mov.fecha)) {
         const currency = mov.moneda;
         if (currency) {
           monthly[currency] = (monthly[currency] || 0) + safeParseFloat(mov.comision);
@@ -91,11 +92,11 @@ function ArbitrajeApp({ movements, onNavigate }) {
 
   // Calcular ganancias de hoy
   const todayArbitrageProfits = useMemo(() => {
-    const today = new Date().toISOString().split('T')[0];
+    const today = getTodayLocalDate();
     const daily = {};
 
     arbitrageMovements.forEach(mov => {
-      if (mov.fecha === today) {
+      if (isToday(mov.fecha)) {
         const currency = mov.moneda;
         if (currency) {
           daily[currency] = (daily[currency] || 0) + safeParseFloat(mov.comision);
@@ -497,7 +498,7 @@ function ArbitrajeApp({ movements, onNavigate }) {
                   <span className="text-xs sm:text-sm text-gray-600">Operaciones este mes:</span>
                   <span className="font-semibold text-gray-900 text-sm sm:text-base">
                     {arbitrageMovements.filter(mov => 
-                      mov.fecha && mov.fecha.substring(0, 7) === new Date().toISOString().substring(0, 7)
+                      mov.fecha && isCurrentMonth(mov.fecha)
                     ).length}
                   </span>
                 </div>

--- a/src/features/commissions/ComisionesApp.jsx
+++ b/src/features/commissions/ComisionesApp.jsx
@@ -16,6 +16,7 @@ import {
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Legend, ResponsiveContainer } from 'recharts';
 import { FormInput, formatAmountWithCurrency } from '../../shared/components/forms';
 import { safeParseFloat } from '../../shared/services/safeOperations';
+import { getTodayLocalDate, getCurrentYearMonth, isCurrentMonth, isToday } from '../../shared/utils/dateUtils';
 
 /** COMPONENTE PRINCIPAL DE ANÁLISIS DE COMISIONES */
 function ComisionesApp({ movements, onNavigate }) {
@@ -108,10 +109,10 @@ function ComisionesApp({ movements, onNavigate }) {
 
   // Calcular comisiones de hoy
   const todayCommissions = useMemo(() => {
-    const today = new Date().toISOString().split('T')[0];
+    const today = getTodayLocalDate();
     const daily = {};
     commissionMovements.forEach(mov => {
-      if (mov.fecha === today) {
+      if (isToday(mov.fecha)) {
         const currency = mov.monedaComision || mov.moneda;
         if (currency) {
           daily[currency] = (daily[currency] || 0) + safeParseFloat(mov.comision);
@@ -123,10 +124,10 @@ function ComisionesApp({ movements, onNavigate }) {
 
   // Calcular comisiones del mes actual
   const currentMonthCommissions = useMemo(() => {
-    const currentYearMonth = new Date().toISOString().substring(0, 7);
+    const currentYearMonth = getCurrentYearMonth();
     const monthly = {};
     commissionMovements.forEach(mov => {
-      if (mov.fecha && mov.fecha.substring(0, 7) === currentYearMonth) {
+      if (mov.fecha && isCurrentMonth(mov.fecha)) {
         const currency = mov.monedaComision || mov.moneda;
         if (currency) {
           monthly[currency] = (monthly[currency] || 0) + safeParseFloat(mov.comision);

--- a/src/features/expenses/GastosApp.jsx
+++ b/src/features/expenses/GastosApp.jsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react';
 import { formatAmountWithCurrency } from '../../shared/components/forms';
 import { safeParseFloat } from '../../shared/services/safeOperations';
+import { getTodayLocalDate, isToday } from '../../shared/utils/dateUtils';
 
 /** COMPONENTE PRINCIPAL DE GASTOS */
 function GastosApp({ movements, onEditMovement, onDeleteMovement, onViewMovementDetail, onNavigate }) {
@@ -58,11 +59,11 @@ function GastosApp({ movements, onEditMovement, onDeleteMovement, onViewMovement
 
   // Calcular gastos del día actual
   const todayExpensesByCurrency = useMemo(() => {
-    const today = new Date().toISOString().split('T')[0];
+    const today = getTodayLocalDate();
     const daily = {};
 
     allExpenses.forEach(mov => {
-      if (mov.fecha === today) {
+      if (isToday(mov.fecha)) {
         const currency = mov.moneda;
         if (currency) {
           daily[currency] = (daily[currency] || 0) + safeParseFloat(mov.monto);

--- a/src/features/financial-operations/FinancialOperationsApp.jsx
+++ b/src/features/financial-operations/FinancialOperationsApp.jsx
@@ -7,6 +7,7 @@ import {
   safeCalculation,
   safeArray 
 } from '../../shared/services/safeOperations';
+import { getTodayLocalDate, getDayName } from '../../shared/utils/dateUtils';
 import {
   FormInput,
   FormSelect,
@@ -43,12 +44,8 @@ function DynamicFormFieldGroups({ groups }) {
 const FinancialOperationsApp = ({ onSaveMovement, initialMovementData, onCancelEdit, clients, onSaveClient }) => {
   const [formData, setFormData] = useState({
     cliente: '',
-    fecha: new Date().toISOString().split('T')[0], // Fecha actual por defecto
-    nombreDia: (() => {
-      const today = new Date();
-      const dayNames = ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'];
-      return dayNames[today.getDay()];
-    })(), // Día actual
+    fecha: getTodayLocalDate(), // Fecha actual por defecto
+    nombreDia: getDayName(getTodayLocalDate()), // Día actual
     detalle: '',
     operacion: '', // Sin predeterminado
     subOperacion: '', // Sin auto-selección
@@ -123,20 +120,7 @@ const FinancialOperationsApp = ({ onSaveMovement, initialMovementData, onCancelE
       // Calcular día de la semana para fechas - VERSIÓN SEGURA
       if (field === 'fecha') {
         if (value && typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
-          try {
-            // Parse date as local time to avoid timezone issues
-            const [year, month, day] = value.split('-').map(Number);
-            const date = new Date(year, month - 1, day); // month is 0-indexed
-            
-                         if (!isNaN(date.getTime())) {
-               const dayNames = ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'];
-               newState.nombreDia = dayNames[date.getDay()];
-             } else {
-              newState.nombreDia = '';
-            }
-          } catch (error) {
-            newState.nombreDia = '';
-          }
+          newState.nombreDia = getDayName(value);
         } else {
           newState.nombreDia = '';
         }
@@ -322,12 +306,8 @@ const FinancialOperationsApp = ({ onSaveMovement, initialMovementData, onCancelE
   const clearForm = () => {
     setFormData({
       cliente: '',
-      fecha: new Date().toISOString().split('T')[0], // Fecha actual por defecto
-      nombreDia: (() => {
-        const today = new Date();
-        const dayNames = ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'];
-        return dayNames[today.getDay()];
-      })(), // Día actual
+      fecha: getTodayLocalDate(), // Fecha actual por defecto
+      nombreDia: getDayName(getTodayLocalDate()), // Día actual
       detalle: '',
       operacion: '', // Sin predeterminado
       subOperacion: '', // Sin auto-selección

--- a/src/features/utility/UtilidadApp.jsx
+++ b/src/features/utility/UtilidadApp.jsx
@@ -17,6 +17,7 @@ import {
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Legend, ResponsiveContainer } from 'recharts';
 import { FormInput, formatAmountWithCurrency } from '../../shared/components/forms';
 import { safeParseFloat } from '../../shared/services/safeOperations';
+import { getTodayLocalDate, getCurrentYearMonth, isCurrentMonth, isToday } from '../../shared/utils/dateUtils';
 // import { handleBusinessLogicError } from '../../shared/services/errorHandler';
 
 /** COMPONENTE PRINCIPAL DE ANÁLISIS DE UTILIDAD */
@@ -207,11 +208,11 @@ function UtilidadApp({ movements, onNavigate }) {
 
   // Utilidad del mes actual - solo VENTA por divisa
   const currentMonthUtility = useMemo(() => {
-    const currentYearMonth = new Date().toISOString().substring(0, 7);
+    const currentYearMonth = getCurrentYearMonth();
     const monthlyVenta = {};
 
     processedMovements
-      .filter(mov => mov.fecha && mov.fecha.substring(0, 7) === currentYearMonth && mov.gananciaCalculada !== 0 && mov.subOperacion === 'VENTA')
+      .filter(mov => mov.fecha && isCurrentMonth(mov.fecha) && mov.gananciaCalculada !== 0 && mov.subOperacion === 'VENTA')
       .forEach(mov => {
         // Usar moneda TC original (donde se deposita la ganancia)
         const monedaUtilidad = mov.monedaTC || 'PESO';
@@ -223,11 +224,11 @@ function UtilidadApp({ movements, onNavigate }) {
 
   // Utilidad de hoy - solo VENTA por divisa
   const todayUtility = useMemo(() => {
-    const today = new Date().toISOString().split('T')[0];
+    const today = getTodayLocalDate();
     const dailyVenta = {};
 
     processedMovements
-      .filter(mov => mov.fecha === today && mov.gananciaCalculada !== 0 && mov.subOperacion === 'VENTA')
+      .filter(mov => isToday(mov.fecha) && mov.gananciaCalculada !== 0 && mov.subOperacion === 'VENTA')
       .forEach(mov => {
         // Usar moneda TC original (donde se deposita la ganancia)
         const monedaUtilidad = mov.monedaTC || 'PESO';

--- a/src/shared/utils/dateUtils.js
+++ b/src/shared/utils/dateUtils.js
@@ -1,0 +1,72 @@
+/**
+ * Utilidades para manejo de fechas sin problemas de zona horaria
+ */
+
+/**
+ * Obtiene la fecha actual en formato YYYY-MM-DD usando la zona horaria local
+ * @returns {string} Fecha en formato YYYY-MM-DD
+ */
+export const getTodayLocalDate = () => {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, '0');
+  const day = String(today.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+/**
+ * Obtiene el año-mes actual en formato YYYY-MM usando la zona horaria local
+ * @returns {string} Año-mes en formato YYYY-MM
+ */
+export const getCurrentYearMonth = () => {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, '0');
+  return `${year}-${month}`;
+};
+
+/**
+ * Convierte una fecha en formato YYYY-MM-DD a objeto Date local
+ * @param {string} dateString - Fecha en formato YYYY-MM-DD
+ * @returns {Date} Objeto Date en zona horaria local
+ */
+export const parseLocalDate = (dateString) => {
+  if (!dateString || typeof dateString !== 'string') return null;
+  
+  const [year, month, day] = dateString.split('-').map(Number);
+  if (!year || !month || !day) return null;
+  
+  return new Date(year, month - 1, day); // month es 0-indexed
+};
+
+/**
+ * Obtiene el nombre del día de la semana para una fecha dada
+ * @param {string} dateString - Fecha en formato YYYY-MM-DD
+ * @returns {string} Nombre del día de la semana
+ */
+export const getDayName = (dateString) => {
+  const date = parseLocalDate(dateString);
+  if (!date || isNaN(date.getTime())) return '';
+  
+  const dayNames = ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'];
+  return dayNames[date.getDay()];
+};
+
+/**
+ * Verifica si una fecha está en el mes actual
+ * @param {string} dateString - Fecha en formato YYYY-MM-DD
+ * @returns {boolean} true si la fecha está en el mes actual
+ */
+export const isCurrentMonth = (dateString) => {
+  if (!dateString) return false;
+  return dateString.substring(0, 7) === getCurrentYearMonth();
+};
+
+/**
+ * Verifica si una fecha es hoy
+ * @param {string} dateString - Fecha en formato YYYY-MM-DD
+ * @returns {boolean} true si la fecha es hoy
+ */
+export const isToday = (dateString) => {
+  return dateString === getTodayLocalDate();
+};


### PR DESCRIPTION
Replaced `toISOString()` date handling with local date utilities to fix dates displaying one day ahead.

The previous use of `toISOString()` converted dates to UTC, causing a one-day discrepancy in displayed dates for users in timezones ahead of UTC. New utility functions ensure dates are handled in the local timezone.

---
<a href="https://cursor.com/background-agent?bcId=bc-d43fe00c-9cb8-448f-9995-c24c6fee0de7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d43fe00c-9cb8-448f-9995-c24c6fee0de7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>