### PR TITLE
Fix recurring auto-selection bug

### DIFF
--- a/src/features/arbitrage/ArbitrajeApp.jsx
+++ b/src/features/arbitrage/ArbitrajeApp.jsx
@@ -401,7 +401,7 @@ function ArbitrajeApp({ movements, onNavigate }) {
 
                       {/* Información adicional de arbitraje */}
                       {(mov.tc || mov.tcVenta) && (
-                        <div className="border-t pt-2 mt-2">
+                        <div className="border-t pt-2">
                           <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 sm:gap-3 text-xs">
                             {mov.tc && (
                               <div>
@@ -421,7 +421,7 @@ function ArbitrajeApp({ movements, onNavigate }) {
                     </div>
 
                     {/* Estado de la operación */}
-                    <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mt-3 pt-3 border-t border-indigo-200 gap-2">
+                    <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center pt-3 border-t border-indigo-200 gap-2">
                       <span className={`px-3 py-1 rounded-full text-xs font-medium ${
                         mov.estado === 'realizado' 
                           ? 'bg-success-100 text-success-700' 

--- a/src/features/clients/ClientesApp.jsx
+++ b/src/features/clients/ClientesApp.jsx
@@ -573,7 +573,7 @@ function AnalyticsCliente({ cliente, onBack, calcularFrecuencia }) {
 
               <div className="bg-success-50 rounded-lg p-3 sm:p-4">
                 <div className="text-xl sm:text-2xl lg:text-3xl font-bold text-success-600 truncate">
-                  ${((cliente.volumenTotal || 0).toFixed(0)).replace(/\B(?=(\d{3})+(?!\d))/g, '.')}
+                  {formatAmountWithCurrency(cliente.volumenTotal || 0, 'PESO', { showSymbol: false, decimals: 0 })}
                 </div>
                 <div className="text-xs sm:text-sm text-success-600 font-medium">Volumen Total</div>
               </div>

--- a/src/features/expenses/GastosApp.jsx
+++ b/src/features/expenses/GastosApp.jsx
@@ -183,7 +183,7 @@ function GastosApp({ movements, onEditMovement, onDeleteMovement, onViewMovement
           
           {/* Indicador de búsqueda activa */}
           {searchTerm && (
-            <div className="flex flex-wrap items-center gap-2 mt-3 pt-3 border-t border-gray-100">
+            <div className="flex flex-wrap items-center gap-2 pt-3 border-t border-gray-100">
               <Search size={14} className="text-gray-400" />
               <span className="text-xs sm:text-sm text-gray-600">Búsqueda activa:</span>
               <span className="px-2 py-1 bg-error-100 text-error-700 rounded-full text-xs">
@@ -350,7 +350,7 @@ function GastoCard({ movement, onEdit, onDelete, onViewDetail }) {
         </div>
 
         {/* Botones de acción */}
-        <div className="flex justify-end gap-1 border-t pt-3 mt-3">
+        <div className="flex justify-end gap-1 border-t pt-3">
           <button 
             onClick={() => onViewDetail(movement)} 
             className="p-2 text-primary-600 hover:bg-primary-50 rounded-lg transition-colors touch-target"

--- a/src/features/financial-operations/FinancialOperationsApp.jsx
+++ b/src/features/financial-operations/FinancialOperationsApp.jsx
@@ -390,7 +390,7 @@ const FinancialOperationsApp = ({ onSaveMovement, initialMovementData, onCancelE
   };
 
   const renderEstadoYPor = () => (
-    <div className="grid grid-cols-2 gap-2 mt-2">
+    <div className="grid grid-cols-2 gap-2">
       <FormSelect
         label="Estado de retiro"
         name="estado"
@@ -587,7 +587,7 @@ const FinancialOperationsApp = ({ onSaveMovement, initialMovementData, onCancelE
 
         {/* Resumen para operaciones COMPRA/VENTA */}
         {(['COMPRA', 'VENTA'].includes(formData.subOperacion) && formData.total) && (
-          <div className="bg-primary-50 border border-primary-200 rounded-lg p-4 mt-4">
+          <div className="bg-primary-50 border border-primary-200 rounded-lg p-4">
             <h3 className="text-sm font-semibold text-primary-900 mb-2">Resumen de la Operación</h3>
             <div className="grid grid-cols-2 gap-4 text-sm">
               <div>
@@ -602,7 +602,7 @@ const FinancialOperationsApp = ({ onSaveMovement, initialMovementData, onCancelE
                   {formatAmountWithCurrency(formData.tc, formData.monedaTC)}
                 </div>
               </div>
-              <div className="col-span-2 border-t border-primary-200 pt-2 mt-2">
+              <div className="col-span-2 border-t border-primary-200 pt-2">
                 <span className="text-primary-700">Total Final:</span>
                 <div className="text-lg font-bold text-primary-900">
                   {formatAmountWithCurrency(formData.total, formData.monedaTC)}

--- a/src/features/financial-operations/FinancialOperationsApp.jsx
+++ b/src/features/financial-operations/FinancialOperationsApp.jsx
@@ -277,10 +277,10 @@ const FinancialOperationsApp = ({ onSaveMovement, initialMovementData, onCancelE
           newState.monedaComision = newState.moneda;
         }
         
-        // Auto-completar cuenta de comisión cuando cambia la cuenta principal
-        if (field === 'cuenta') {
-          newState.cuentaComision = newState.cuenta;
-        }
+        // NO auto-completar cuenta de comisión - debe ser seleccionada manualmente
+        // if (field === 'cuenta') {
+        //   newState.cuentaComision = newState.cuenta;
+        // }
 
         // Calcular monto de comisión cuando cambia el monto o el porcentaje
         if (['monto', 'comisionPorcentaje'].includes(field)) {

--- a/src/features/lenders/PrestamistasApp.jsx
+++ b/src/features/lenders/PrestamistasApp.jsx
@@ -255,7 +255,7 @@ function PrestamistasApp({ clients, movements, onNavigate }) {
                         )}
 
                         {/* Información de contacto */}
-                        <div className="mt-3 sm:mt-4 pt-2 sm:pt-3 border-t border-warning-200">
+                        <div className="pt-2 sm:pt-3 border-t border-warning-200">
                           <div className="flex items-center gap-1 text-xs text-warning-700 mb-1">
                             <Phone size={12} />
                             <span className="truncate">{summaryData.client.telefono}</span>

--- a/src/features/utility/UtilidadApp.jsx
+++ b/src/features/utility/UtilidadApp.jsx
@@ -503,7 +503,7 @@ function UtilidadApp({ movements, onNavigate }) {
                         </div>
                       </div>
                       
-                                              <div className="pt-2 border-t border-gray-200 mt-2">
+                                              <div className="pt-2 border-t border-gray-200">
                           <div className="flex justify-between items-center">
                             <span className="text-xs text-gray-500">Valuación</span>
                             <span className="font-medium text-primary-600 text-sm">
@@ -511,7 +511,7 @@ function UtilidadApp({ movements, onNavigate }) {
                             </span>
                           </div>
                           {data.utilidadPorVenta !== 0 && (
-                            <div className="mt-1">
+                            <div>
                               <div className="flex justify-between text-xs">
                                 <span className="text-gray-500">Util. Venta</span>
                                 <span className="text-emerald-600 font-medium">

--- a/src/shared/components/forms/ClientAutocomplete.jsx
+++ b/src/shared/components/forms/ClientAutocomplete.jsx
@@ -251,7 +251,7 @@ const ClientAutocomplete = forwardRef(({
 
           {/* Dropdown de opciones */}
           {isOpen && (
-            <div className="absolute z-50 w-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-y-auto">
+            <div className="absolute z-50 w-full bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-y-auto">
               {filteredClients.length > 0 ? (
                 <>
                   {filteredClients.map((client, index) => (

--- a/src/shared/components/forms/MixedPaymentGroup.jsx
+++ b/src/shared/components/forms/MixedPaymentGroup.jsx
@@ -1,6 +1,7 @@
 import React, { forwardRef } from 'react';
 import { Plus, X } from 'lucide-react';
 import { safeParseFloat, safeArray } from '../../services/safeOperations';
+import { formatAmountWithCurrency } from '../../services/formatters';
 import FormSelect from './FormSelect';
 import CurrencyInput from './CurrencyInput';
 
@@ -146,13 +147,13 @@ const MixedPaymentGroup = ({
           <div>
             <span className="text-gray-600">Total Pagos:</span>
             <span className="ml-2 font-medium text-gray-900">
-              ${totalPayments.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, '.')}
+              {formatAmountWithCurrency(totalPayments, currency, { showSymbol: false })}
             </span>
           </div>
           <div>
             <span className="text-gray-600">Esperado:</span>
             <span className="ml-2 font-medium text-gray-900">
-              ${totalExpected.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, '.')}
+              {formatAmountWithCurrency(totalExpected, currency, { showSymbol: false })}
             </span>
           </div>
         </div>
@@ -160,7 +161,7 @@ const MixedPaymentGroup = ({
         {!isBalanced && (
           <div className="text-sm">
             <span className={`font-medium ${difference > 0 ? 'text-red-600' : 'text-green-600'}`}>
-              {difference > 0 ? 'Falta:' : 'Sobra:'} ${Math.abs(difference).toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, '.')}
+              {difference > 0 ? 'Falta:' : 'Sobra:'} {formatAmountWithCurrency(Math.abs(difference), currency, { showSymbol: false })}
             </span>
           </div>
         )}

--- a/src/shared/components/forms/MixedPaymentGroup.jsx
+++ b/src/shared/components/forms/MixedPaymentGroup.jsx
@@ -158,7 +158,7 @@ const MixedPaymentGroup = ({
         </div>
         
         {!isBalanced && (
-          <div className="mt-2 text-sm">
+          <div className="text-sm">
             <span className={`font-medium ${difference > 0 ? 'text-red-600' : 'text-green-600'}`}>
               {difference > 0 ? 'Falta:' : 'Sobra:'} ${Math.abs(difference).toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, '.')}
             </span>

--- a/src/shared/components/forms/WalletButtonGroup.jsx
+++ b/src/shared/components/forms/WalletButtonGroup.jsx
@@ -16,14 +16,9 @@ export const WalletButtonGroup = React.forwardRef(({
     let newValue = value || '';
     
     if (buttonType === 'socio') {
-      // Si es socio, mantener el tipo actual SOLO si ya hay uno seleccionado
-      if (newValue) {
-        const currentType = newValue.includes('digital') ? 'digital' : 'efectivo';
-        newValue = buttonValue.replace('_efectivo', `_${currentType}`);
-      } else {
-        // Si no hay valor, solo seleccionar el socio sin tipo automático
-        newValue = buttonValue;
-      }
+      // NO auto-seleccionar tipo - solo seleccionar el socio
+      const socioName = buttonValue.replace('_efectivo', '');
+      newValue = socioName;
     } else {
       // Si es tipo, mantener el socio actual SOLO si ya hay uno seleccionado
       if (newValue) {

--- a/src/shared/components/forms/WalletTCButtonGroup.jsx
+++ b/src/shared/components/forms/WalletTCButtonGroup.jsx
@@ -20,14 +20,9 @@ export const WalletTCButtonGroup = React.forwardRef(({
     let newValue = value || '';
     
     if (buttonType === 'socio') {
-      // Si es socio, mantener el tipo actual SOLO si ya hay uno seleccionado
-      if (newValue) {
-        const currentType = newValue.includes('digital') ? 'digital' : 'efectivo';
-        newValue = buttonValue.replace('_efectivo', `_${currentType}`);
-      } else {
-        // Si no hay valor, solo seleccionar el socio sin tipo automático
-        newValue = buttonValue;
-      }
+      // NO auto-seleccionar tipo - solo seleccionar el socio
+      const socioName = buttonValue.replace('_efectivo', '');
+      newValue = socioName;
     } else {
       // Si es tipo, mantener el socio actual SOLO si ya hay uno seleccionado
       if (newValue) {

--- a/src/shared/constants/fieldConfigs.js
+++ b/src/shared/constants/fieldConfigs.js
@@ -153,7 +153,7 @@ export const specificFieldsConfig = {
           { label: 'Moneda Comisión', name: 'monedaComision', type: 'select', options: monedas, readOnly: true, calculated: true, gridCols: 'col-span-2' }
         ],
         [
-          { label: 'Cuenta Comisión', name: 'cuentaComision', type: 'wallet-buttons', gridCols: 'col-span-2', readOnly: true, calculated: true }
+          { label: 'Cuenta Comisión', name: 'cuentaComision', type: 'wallet-buttons', gridCols: 'col-span-2', required: true }
         ],
         [
           { label: `${formData.subOperacion || 'Ingreso/Egreso'} Real`, name: 'montoReal', type: 'number', readOnly: true, calculated: true, gridCols: 'col-span-2' }


### PR DESCRIPTION
Disable auto-selection of the commission account and make it a required field to fix a recurring bug where it was automatically selected when choosing an income/expense account.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa5fb057-34cb-411c-950d-c9feafb7658c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aa5fb057-34cb-411c-950d-c9feafb7658c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>