### PR TITLE
Mover monedas a disposición horizontal

### DIFF
--- a/src/shared/components/forms/ButtonSelectGroup.jsx
+++ b/src/shared/components/forms/ButtonSelectGroup.jsx
@@ -21,7 +21,7 @@ const ButtonSelectGroup = ({
   const getButtonClasses = (optionValue) => {
     const isActive = value === optionValue;
     const baseClasses = isMoneda
-      ? 'px-1 py-1 text-xs font-medium flex items-center justify-center rounded-md border transition-all min-w-[40px]'
+      ? 'px-2 py-1 text-xs font-medium flex items-center justify-center rounded-md border transition-all min-w-[50px]'
       : isOperacion
         ? 'px-2 py-3 text-sm font-medium flex items-center justify-center rounded-lg border transition-all min-h-[80px]'
         : 'px-4 py-2.5 text-sm font-medium flex items-center justify-center rounded-lg border transition-all';
@@ -88,9 +88,9 @@ const ButtonSelectGroup = ({
                   const emoji = parts[0];
                   const code = parts[1];
                   return (
-                    <div className="flex flex-col items-center gap-0">
+                    <div className="flex flex-row items-center gap-1">
                       <span className="text-sm leading-none">{emoji}</span>
-                      <span className="text-[8px] leading-none">{code}</span>
+                      <span className="text-[10px] leading-none">{code}</span>
                     </div>
                   );
                 })()


### PR DESCRIPTION
Adjust currency display in ButtonSelectGroup to prevent flags and codes from stacking vertically.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7b006c9-0dd4-4209-9728-5bc0d29cf31e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c7b006c9-0dd4-4209-9728-5bc0d29cf31e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

